### PR TITLE
feat: add mobile hamburger nav menu with overlay support

### DIFF
--- a/build.js
+++ b/build.js
@@ -7,7 +7,7 @@ const userscriptBanner = `
 // @name        JandanX
 // @namespace   none
 // @description twitter like jandan!
-// @version     0.3.0
+// @version     1.0.1
 // @author      xianii
 // @namespace   none
 // @exclude     none

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "jandanx",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "jandanx",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "license": "ISC",
       "devDependencies": {
         "esbuild": "^0.25.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jandanx",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "A user script change jandan.net into twitter like layout",
   "main": "jandanX.user.js",
   "scripts": {

--- a/src/jandanX.css
+++ b/src/jandanX.css
@@ -242,8 +242,10 @@ aside.sidebar {
 	#layout-row {
 		flex-direction: column;
 	}
-	div.new-nav {
-		display: none;
+
+	/* Hide .new-nav on mobile devices since we're using mobile menu */
+	.new-nav {
+		display: none !important;
 	}
 }
 .top-nav > div.nav-item {
@@ -341,4 +343,108 @@ div#float-window {
 	height: 50px;
 	overflow: hidden;
 	margin: 0px 0px 20px 20px;
+}
+
+/* Mobile menu styles */
+@media (max-width: 768px) {
+	/* Hamburger button - now positioned at bottom right */
+	.hamburger {
+		display: block;
+		width: 40px;
+		height: 40px;
+		position: fixed;
+		bottom: 20px;
+		right: 20px;
+		cursor: pointer;
+		z-index: 1000;
+		border-radius: 50%;
+		background-color: var(--jd-bg);
+		box-shadow: 0 2px 8px rgba(0, 0, 0, 0.3);
+		display: flex;
+		align-items: center;
+		justify-content: center;
+	}
+	
+	.hamburger span {
+		display: block;
+		height: 4px;
+		width: 24px;
+		background-color: var(--jd-plain);
+		border-radius: 2px;
+		position: absolute;
+		transition: all 0.3s ease;
+		left: 8px; /* Center the spans */
+	}
+	
+	.hamburger span:nth-child(1) {
+		top: 10px;
+	}
+	
+	.hamburger span:nth-child(2) {
+		top: 18px;
+	}
+	
+	.hamburger span:nth-child(3) {
+		top: 26px;
+	}
+	
+	/* When menu is active, prevent background scrolling */
+	body.menu-active {
+		overflow: hidden;
+	}
+	
+	/* Hamburger animation when menu is open */
+	.hamburger.active span:nth-child(1) {
+		transform: rotate(45deg) translate(5px, 5px);
+	}
+	
+	.hamburger.active span:nth-child(2) {
+		opacity: 0;
+	}
+	
+	.hamburger.active span:nth-child(3) {
+		transform: rotate(-45deg) translate(5px, -5px);
+	}
+	
+	/* Mobile nav menu */
+	.mobile-nav-menu {
+		display: none;
+		position: fixed;
+		width: 280px;
+		background-color: var(--jd-bg);
+		z-index: 1000;
+		padding: 16px;
+		box-shadow: 0 2px 8px rgba(0, 0, 0, 0.3);
+		border-radius: 8px;
+		border: 1px solid rgba(255, 255, 255, 0.1);
+	}
+	
+	.mobile-nav-menu.active {
+		display: block;
+	}
+	
+	/* Mask layer */
+	.mask {
+		position: fixed;
+		top: 0;
+		left: 0;
+		width: 100%;
+		height: 100%;
+		background-color: rgba(0, 0, 0, 0.5);
+		z-index: 999;
+		display: none;
+	}
+	
+	.mask.active {
+		display: block;
+	}
+	
+	.nav-item > a {
+		padding-left: 16px !important;
+	}
+	
+	/* Hide logo when mobile menu is active */
+	body.menu-active .logo {
+		display: none !important;
+	}
 }

--- a/src/jandanX.js
+++ b/src/jandanX.js
@@ -90,8 +90,81 @@ import css from "./jandanX.css"
 
 		const newNav = document.createElement("div")
 		newNav.classList.add("new-nav")
-		newNav.appendChild(newLogo)
-		newNav.appendChild(Nav)
+
+		let hamburger = null
+		let mobileMenu = null
+		let mask = null
+
+		function closeMobileMenu() {
+			if (!hamburger || !mobileMenu || !mask) return
+			mobileMenu.classList.remove("active")
+			hamburger.classList.remove("active")
+			mask.classList.remove("active")
+			document.body.classList.remove("menu-active")
+		}
+
+		function positionMobileMenu() {
+			if (!hamburger || !mobileMenu) return
+			const rect = hamburger.getBoundingClientRect()
+			const gap = 8
+			mobileMenu.style.top = `${Math.max(8, rect.top - mobileMenu.offsetHeight - gap)}px`
+			mobileMenu.style.left = `${Math.max(8, rect.right - mobileMenu.offsetWidth)}px`
+		}
+
+		function clearMobileMenu() {
+			if (hamburger) hamburger.remove()
+			if (mobileMenu) mobileMenu.remove()
+			if (mask) mask.remove()
+			hamburger = null
+			mobileMenu = null
+			mask = null
+			document.body.classList.remove("menu-active")
+		}
+
+		function createMobileMenu() {
+			hamburger = document.createElement("div")
+			hamburger.classList.add("hamburger")
+			hamburger.innerHTML = "<span></span><span></span><span></span>"
+
+			mobileMenu = document.createElement("div")
+			mobileMenu.classList.add("mobile-nav-menu")
+			mobileMenu.appendChild(Nav)
+
+			mask = document.createElement("div")
+			mask.classList.add("mask")
+
+			document.body.appendChild(mask)
+			document.body.appendChild(mobileMenu)
+			document.body.appendChild(hamburger)
+
+			hamburger.addEventListener("click", function () {
+				mobileMenu.classList.toggle("active")
+				hamburger.classList.toggle("active")
+				mask.classList.toggle("active")
+				if (mobileMenu.classList.contains("active")) {
+					document.body.classList.add("menu-active")
+					positionMobileMenu()
+				} else {
+					document.body.classList.remove("menu-active")
+				}
+			})
+
+			mask.addEventListener("click", closeMobileMenu)
+		}
+
+		function renderNavByViewport() {
+			const isMobile = window.innerWidth <= 768
+			if (isMobile) {
+				if (!mobileMenu) createMobileMenu()
+				if (newNav.contains(newLogo)) newNav.removeChild(newLogo)
+				if (newNav.contains(Nav)) newNav.removeChild(Nav)
+				if (!mobileMenu.contains(Nav)) mobileMenu.appendChild(Nav)
+			} else {
+				clearMobileMenu()
+				if (!newNav.contains(newLogo)) newNav.appendChild(newLogo)
+				if (!newNav.contains(Nav)) newNav.appendChild(Nav)
+			}
+		}
 
 		// Get the necessary elements
 		const mainLayout = [
@@ -124,6 +197,14 @@ import css from "./jandanX.css"
 
 		// Add footer
 		layout.appendChild(footer)
+
+		renderNavByViewport()
+		window.addEventListener("resize", () => {
+			renderNavByViewport()
+			if (mobileMenu && mobileMenu.classList.contains("active")) {
+				positionMobileMenu()
+			}
+		})
 
 		// Add styles
 		GM_addStyle(css)


### PR DESCRIPTION
Implement a mobile-specific navigation flow by introducing a floating hamburger button, slide-up menu container behavior, and a backdrop mask. This replaces the previous mobile nav visibility approach to improve navigation usability on small screens and prevent background scrolling while the menu is open.

Also update userscript/package versions to 1.0.1 to ship the new mobile navigation experience.